### PR TITLE
Fix: Exclude courses from different terms in conflict detection

### DIFF
--- a/frontend/src/components/DailyCalendar.tsx
+++ b/frontend/src/components/DailyCalendar.tsx
@@ -1818,6 +1818,20 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
 
                 // Only check conflicts for events on the same day
                 if (event1.day_of_week === event2.day_of_week) {
+                    // Check if date ranges overlap (if both events have date ranges)
+                    // Events from different terms shouldn't conflict
+                    if (event1.start_date && event1.end_date && event2.start_date && event2.end_date) {
+                        const date1Start = new Date(event1.start_date);
+                        const date1End = new Date(event1.end_date);
+                        const date2Start = new Date(event2.start_date);
+                        const date2End = new Date(event2.end_date);
+                        
+                        // Check if date ranges don't overlap - if so, skip (no conflict)
+                        if (date1End < date2Start || date2End < date1Start) {
+                            continue; // Different terms, no conflict
+                        }
+                    }
+                    
                     const start1 = timeToMinutes(event1.startTime);
                     const end1 = timeToMinutes(event1.endTime);
                     const start2 = timeToMinutes(event2.startTime);
@@ -1852,6 +1866,20 @@ const WeeklyCalendar: React.FC<WeeklyCalendarProps> = ({
 
                 // Only check conflicts for events on the same day
                 if (event1.day_of_week === event2.day_of_week) {
+                    // Check if date ranges overlap (if both events have date ranges)
+                    // Events from different terms shouldn't conflict
+                    if (event1.start_date && event1.end_date && event2.start_date && event2.end_date) {
+                        const date1Start = new Date(event1.start_date);
+                        const date1End = new Date(event1.end_date);
+                        const date2Start = new Date(event2.start_date);
+                        const date2End = new Date(event2.end_date);
+                        
+                        // Check if date ranges don't overlap - if so, skip (no conflict)
+                        if (date1End < date2Start || date2End < date1Start) {
+                            continue; // Different terms, no conflict
+                        }
+                    }
+                    
                     const start1 = timeToMinutes(event1.startTime);
                     const end1 = timeToMinutes(event1.endTime);
                     const start2 = timeToMinutes(event2.startTime);


### PR DESCRIPTION
- Added date range overlap checking in conflict detection
- Courses from different terms (Fall 2025 vs Winter 2026) no longer counted as conflicts
- Only courses with overlapping date ranges and same day/time are considered conflicts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates conflict detection to ignore events with non-overlapping date ranges, only flagging overlaps within the same term, day, and time.
> 
> - **Frontend**
>   - **Conflict detection refinement** in `frontend/src/components/DailyCalendar.tsx`:
>     - In `getConflictsCount` and `getConflictingEvents`, add date range overlap checks (`start_date`/`end_date`) and skip conflicts when ranges don’t overlap.
>     - Conflicts now require same `day_of_week`, overlapping times, and overlapping date ranges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4709b634a2be7b5de107c213f0e692023e7b281d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->